### PR TITLE
feat: add rule for fdk:isAuthorative

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,6 +173,26 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.0.0-M5</version>
+                <configuration>
+                    <useSystemClassLoader>false</useSystemClassLoader>
+                    <groups>unit</groups>
+                    <excludedGroups>integration</excludedGroups>
+                    <includes>
+                        <include>**/*.java</include>
+                    </includes>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>3.0.0-M5</version>
+                <configuration>
+                    <groups>integration</groups>
+                    <excludedGroups>unit</excludedGroups>
+                    <includes>
+                        <include>**/*.java</include>
+                    </includes>
+                </configuration>
             </plugin>
 
         </plugins>

--- a/src/main/kotlin/no/fdk/fdk_reasoning_service/model/Enum.kt
+++ b/src/main/kotlin/no/fdk/fdk_reasoning_service/model/Enum.kt
@@ -1,0 +1,5 @@
+package no.fdk.fdk_reasoning_service.model
+
+enum class CatalogType {
+    DATASETS
+}

--- a/src/main/kotlin/no/fdk/fdk_reasoning_service/service/ReasoningService.kt
+++ b/src/main/kotlin/no/fdk/fdk_reasoning_service/service/ReasoningService.kt
@@ -1,6 +1,13 @@
 package no.fdk.fdk_reasoning_service.service
 
 import no.fdk.fdk_reasoning_service.config.ApplicationURI
+import no.fdk.fdk_reasoning_service.model.CatalogType
+import org.apache.jena.rdf.model.Model
+import org.apache.jena.rdf.model.ModelFactory
+import org.apache.jena.reasoner.rulesys.GenericRuleReasoner
+import org.apache.jena.reasoner.rulesys.Rule
+import org.apache.jena.riot.Lang
+import org.apache.jena.riot.RDFDataMgr
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
@@ -11,8 +18,14 @@ private val LOGGER: Logger = LoggerFactory.getLogger(ReasoningService::class.jav
 class ReasoningService(
     private val uris: ApplicationURI
 ) {
-    fun transformCatalogForSPARQL() {
-        LOGGER.debug("Starting reasoning")
-    }
+    fun catalogReasoning(catalogType: CatalogType): Model {
+        LOGGER.debug("Starting $catalogType reasoning")
+        val catalog = RDFDataMgr.loadModel(catalogType.uri(uris), Lang.TURTLE)
 
+        val reasoner = GenericRuleReasoner(Rule.parseRules(datasetRules))
+        val infModel = ModelFactory.createInfModel(reasoner, catalog)
+        infModel.fdkPrefix()
+
+        return infModel
+    }
 }

--- a/src/main/kotlin/no/fdk/fdk_reasoning_service/service/Rules.kt
+++ b/src/main/kotlin/no/fdk/fdk_reasoning_service/service/Rules.kt
@@ -1,0 +1,15 @@
+package no.fdk.fdk_reasoning_service.service
+
+const val datasetRules = """
+    @prefix dcat: <http://www.w3.org/ns/dcat#> .
+    @prefix dct: <http://purl.org/dc/terms/> .
+    @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+    @prefix fdk: <https://raw.githubusercontent.com/Informasjonsforvaltning/fdk-reasoning-service/master/src/main/resources/ontology/fdk.owl#> .
+
+    [isAuthoritative:
+        (?dataset rdf:type dcat:Dataset)
+        (?dataset dct:provenance ?provenance)
+        equal(?provenance, <http://data.brreg.no/datakatalog/provinens/nasjonal>)
+
+        -> (?dataset fdk:isAuthoritative 'true'^^xsd:boolean) ]
+"""

--- a/src/main/kotlin/no/fdk/fdk_reasoning_service/service/Utils.kt
+++ b/src/main/kotlin/no/fdk/fdk_reasoning_service/service/Utils.kt
@@ -1,0 +1,15 @@
+package no.fdk.fdk_reasoning_service.service
+
+import no.fdk.fdk_reasoning_service.config.ApplicationURI
+import no.fdk.fdk_reasoning_service.model.CatalogType
+import org.apache.jena.rdf.model.Model
+
+const val RECORDS_PARAM_TRUE = "catalogrecords=true"
+
+fun Model.fdkPrefix(): Model =
+    setNsPrefix("fdk", "https://raw.githubusercontent.com/Informasjonsforvaltning/fdk-reasoning-service/master/src/main/resources/ontology/fdk.owl#")
+
+fun CatalogType.uri(uris: ApplicationURI): String =
+    when (this) {
+        CatalogType.DATASETS -> "${uris.datasets}?$RECORDS_PARAM_TRUE"
+    }

--- a/src/main/resources/ontology/fdk.owl
+++ b/src/main/resources/ontology/fdk.owl
@@ -1,0 +1,35 @@
+@prefix fdk: <https://raw.githubusercontent.com/Informasjonsforvaltning/fdk-reasoning-service/master/src/main/resources/ontology/fdk.owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+
+fdk:
+  a owl:Ontology ;
+  rdfs:label "FDK vocabulary"@en ;
+  rdfs:comment "Definition of custom triples for internal use"@en .
+
+fdk:isOpenData
+  a owl:DatatypeProperty ;
+  rdfs:domain dcat:Dataset ;
+  rdfs:range xsd:boolean ;
+  rdfs:label "A boolean value to flag an open data resource"@en ;
+  rdfs:comment "A boolean value to flag an open data resource."@en ;
+  rdfs:isDefinedBy fdk: .
+
+fdk:isAuthoritative
+  a owl:DatatypeProperty ;
+  rdfs:domain dcat:Dataset ;
+  rdfs:range xsd:boolean ;
+  rdfs:label "A boolean value to flag a resource with an authoritative origin"@en ;
+  rdfs:comment "A boolean value to flag a resource with an authoritative origin."@en ;
+  rdfs:isDefinedBy fdk: .
+
+fdk:isRelatedToTransportportal
+  a owl:DatatypeProperty ;
+  rdfs:domain dcat:Dataset ;
+  rdfs:range xsd:boolean ;
+  rdfs:label "A boolean value to flag a resource related to Transportportal"@en ;
+  rdfs:comment "A boolean value to flag a resource related to Transportportal."@en ;
+  rdfs:isDefinedBy fdk: .

--- a/src/test/kotlin/no/fdk/fdk_reasoning_service/unit/Reasoning.kt
+++ b/src/test/kotlin/no/fdk/fdk_reasoning_service/unit/Reasoning.kt
@@ -1,0 +1,33 @@
+package no.fdk.fdk_reasoning_service.unit
+
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import no.fdk.fdk_reasoning_service.config.ApplicationURI
+import no.fdk.fdk_reasoning_service.model.CatalogType
+import no.fdk.fdk_reasoning_service.service.ReasoningService
+import no.fdk.fdk_reasoning_service.utils.ApiTestContext
+import no.fdk.fdk_reasoning_service.utils.LOCAL_SERVER_PORT
+import no.fdk.fdk_reasoning_service.utils.TestResponseReader
+import org.apache.jena.rdf.model.ModelFactory
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import kotlin.test.assertTrue
+
+@Tag("unit")
+class Reasoning: ApiTestContext() {
+    private val uris: ApplicationURI = mock()
+    private val reasoningService = ReasoningService(uris)
+
+    private val responseReader = TestResponseReader()
+
+    @Test
+    fun testDatasets() {
+        whenever(uris.datasets)
+            .thenReturn("http://localhost:$LOCAL_SERVER_PORT/datasets/catalogs")
+        val result = reasoningService.catalogReasoning(CatalogType.DATASETS)
+
+        val expected = responseReader.parseTurtleFile("fdk_ready_datasets.ttl")
+
+        assertTrue(result.isIsomorphicWith(expected))
+    }
+}

--- a/src/test/kotlin/no/fdk/fdk_reasoning_service/utils/ResponseMock.kt
+++ b/src/test/kotlin/no/fdk/fdk_reasoning_service/utils/ResponseMock.kt
@@ -2,6 +2,7 @@ package no.fdk.fdk_reasoning_service.utils
 
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock.*
+import java.io.File
 
 const val LOCAL_SERVER_PORT = 5000
 
@@ -11,6 +12,9 @@ fun startMockServer() {
     if(!mockserver.isRunning) {
         mockserver.stubFor(get(urlEqualTo("/ping"))
             .willReturn(aResponse().withStatus(200)))
+
+        mockserver.stubFor(get(urlEqualTo("/datasets/catalogs?catalogrecords=true"))
+            .willReturn(ok(File("src/test/resources/datasets.ttl").readText())))
 
         mockserver.start()
     }

--- a/src/test/kotlin/no/fdk/fdk_reasoning_service/utils/TestResponseReader.kt
+++ b/src/test/kotlin/no/fdk/fdk_reasoning_service/utils/TestResponseReader.kt
@@ -1,0 +1,23 @@
+package no.fdk.fdk_reasoning_service.utils
+
+import org.apache.jena.rdf.model.Model
+import org.apache.jena.rdf.model.ModelFactory
+
+import java.io.InputStreamReader
+import java.io.Reader
+import java.io.StringReader
+import java.nio.charset.StandardCharsets
+
+class TestResponseReader {
+
+    private fun resourceAsReader(resourceName: String): Reader {
+        return InputStreamReader(javaClass.classLoader.getResourceAsStream(resourceName)!!, StandardCharsets.UTF_8)
+    }
+
+    fun parseTurtleFile(filename: String): Model {
+        val expected = ModelFactory.createDefaultModel()
+        expected.read(resourceAsReader(filename), "", "TURTLE")
+        return expected
+    }
+
+}

--- a/src/test/resources/datasets.ttl
+++ b/src/test/resources/datasets.ttl
@@ -1,0 +1,128 @@
+@prefix schema: <http://schema.org/> .
+@prefix dcatapi: <http://dcat.no/dcatapi/> .
+@prefix adms:  <http://www.w3.org/ns/adms#> .
+@prefix iso:   <http://iso.org/25012/2008/dataquality/> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix dqv:   <http://www.w3.org/ns/dqv#> .
+@prefix skos:  <http://www.w3.org/2004/02/skos/core#> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+@prefix dct:   <http://purl.org/dc/terms/> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix dcatno: <http://difi.no/dcatno#> .
+@prefix dcat:  <http://www.w3.org/ns/dcat#> .
+@prefix prov:  <http://www.w3.org/ns/prov#> .
+@prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+@prefix oa:    <http://www.w3.org/ns/oa#> .
+
+<http://brreg.no/catalogs/910298062/datasets/7e4fbd01-2684-45c3-8ac1-70ebfebe8513>
+        a                          dcat:Dataset ;
+        dcatno:informationModel    [ a               skos:Concept , dct:Standard ;
+                                     dct:source      "https://www.staging.fellesdatakatalog.digdir.no/informationmodels/60ecfff8-9ea3-41ee-92cc-7e791d73dac0" ;
+                                     skos:prefLabel  "Felles informasjonsmodell for Person og Enhet"@nb
+                                   ] ;
+        dcatno:objective           "Inngangsleverandører test"@nb ;
+        dct:accessRights           <http://publications.europa.eu/resource/authority/access-right/PUBLIC> ;
+        dct:description            "Inngangsleverandører test"@nb ;
+        dct:provenance             <http://data.brreg.no/datakatalog/provinens/nasjonal> ;
+        dct:publisher              <https://organization-catalogue.staging.fellesdatakatalog.digdir.no/organizations/910244132> ;
+        dct:subject                <https://fellesdatakatalog.brreg.no/api/concepts/ac207ee9-972a-4ba9-a2d6-c368135caf0b> , <https://fellesdatakatalog.brreg.no/api/concepts/5869bbec-f894-47a7-a8de-39a6941a76d1> , <https://fellesdatakatalog.brreg.no/api/concepts/f1dacfe6-e0a9-4400-9b0c-08fb59b51d45> , <https://fellesdatakatalog.brreg.no/api/concepts/9aa8a3f4-9583-4278-a30e-1a3cf6151cfd> ;
+        dct:title                  "Inngangsleverandører test"@nb ;
+        dct:type                   "Data" ;
+        dcat:contactPoint          [ a                        vcard:Organization ;
+                                     vcard:organization-unit  "Ny test"
+                                   ] ;
+        dcat:theme                 <https://psi.norge.no/los/tema/trafikkinformasjon> , <https://psi.norge.no/los/tema/mobilitetstilbud> , <https://psi.norge.no/los/tema/helse-og-omsorg> , <https://psi.norge.no/los/ord/drivstoff-og-ladestasjoner> , <https://psi.norge.no/los/ord/reisebillett> , <https://psi.norge.no/los/tema/lov-og-rett> , <https://psi.norge.no/los/ord/ruteplanlegger> , <https://psi.norge.no/los/tema/kultur-idrett-og-fritid> ;
+        dqv:hasQualityAnnotation   [ a                dqv:QualityAnnotation ;
+                                     dqv:inDimension  <iso:Currentness> ;
+                                     prov:hasBody     []
+                                   ] ;
+        prov:qualifiedAttribution  [ a             prov:Attribution ;
+                                     dcat:hadRole  <http://registry.it.csiro.au/def/isotc211/CI_RoleCode/contributor> ;
+                                     prov:agent    <https://data.brreg.no/enhetsregisteret/api/enheter/991825827>
+                                   ] ;
+        prov:qualifiedAttribution  [ a             prov:Attribution ;
+                                     dcat:hadRole  <http://registry.it.csiro.au/def/isotc211/CI_RoleCode/contributor> ;
+                                     prov:agent    <https://data.brreg.no/enhetsregisteret/api/enheter/984582021>
+                                   ] .
+
+<http://brreg.no/catalogs/910244132/datasets/c32b7a4f-655f-45f6-88f6-d01f05d0f7c2>
+        a                         dcat:Dataset ;
+        dct:accessRights      <http://publications.europa.eu/resource/authority/access-right/PUBLIC> ;
+        dct:description       "bbbb\n\n---\nFormål: "@nb ;
+        dct:provenance        <http://data.brreg.no/datakatalog/provinens/nasjonal> ;
+        dct:publisher         <https://organization-catalogue.staging.fellesdatakatalog.digdir.no/organizations/910244132> ;
+        dct:title             "Fint datasett"@nb ;
+        dcat:distribution         [ a                    dcat:Distribution ;
+                                    dct:description  "Åpent"@nb ;
+                                    dct:format       "json" ;
+                                    dct:license      [ a               dct:LicenseDocument , skos:Concept ;
+                                                           dct:source  "http://data.norge.no/nlod/" ;
+                                                           skos:prefLabel  "Norsk lisens for offentlige data"@no , "Norwegian Licence for Open Government Data"@en
+                                                         ] ;
+                                    dct:title        "TEST"@nb ;
+                                    dcat:accessURL       <https://vg.no>
+                                  ] ;
+        dcat:distribution         [ a               dcat:Distribution ;
+                                    dct:format  "xml"
+                                  ] ;
+        dcat:theme                <http://publications.europa.eu/resource/authority/data-theme/EDUC> ;
+        dqv:hasQualityAnnotation  [ a                dqv:QualityAnnotation ;
+                                    dqv:inDimension  iso:Currentness ;
+                                    oa:hasBody       [ a                 oa:TextualBody ;
+                                                       dct:format    <http://publications.europa.eu/resource/authority/file-type/TXT> ;
+                                                       dct:language  <http://publications.europa.eu/resource/authority/language/NOB>
+                                                     ]
+                                  ] .
+
+<https://fellesdatakatalog.brreg.no/api/concepts/ac207ee9-972a-4ba9-a2d6-c368135caf0b>
+        a                skos:Concept ;
+        dct:identifier   "https://dataverk.nav.no/begrep/BEGREP-1499" ;
+        skos:definition  "En digital løsning som setter en aktør i stand til selv å utføre oppgaver som ikke må utføres av en NAV-ansatt, eller som ikke kan eller bør automatiseres."@nb ;
+        skos:prefLabel   "Selvbetjeningsløsning"@nb .
+
+<http://brreg.no/catalogs/910298062/datasets/12136d8b-024e-4d63-a8ed-5e1885d701cd>
+        a                 dcat:Dataset ;
+        dcatno:objective  "Test"@nb ;
+        dct:accessRights  <http://publications.europa.eu/resource/authority/access-right/PUBLIC> ;
+        dct:description   "Dette er "@nb ;
+        dct:isPartOf      <http://brreg.no/catalogs/910298062/datasets/738c2348-aeb4-4a92-9a10-c39ae6b9f3fe> ;
+        dct:publisher     <https://organization-catalogue.staging.fellesdatakatalog.digdir.no/organizations/910298062> ;
+        dct:relation      [ a  rdfs:Resource ] ;
+        dct:title         "Datter"@nb ;
+        dcat:theme        <https://psi.norge.no/los/tema/arbeid> .
+
+<https://fellesdatakatalog.brreg.no/api/concepts/5869bbec-f894-47a7-a8de-39a6941a76d1>
+        a                skos:Concept ;
+        dct:identifier   "http://begrepskatalogen/begrep/5cd23f5a-dc82-11e5-9b2b-d6d6eb145c82" ;
+        skos:definition  "Test av en verdikjede med fokus på arbeidsprosess/arbeidsflyt og/eller transaksjonsflyt. Man tester da hendelsen/transaksjonen fra den oppstår eller kommer inn i systemet til den er ferdig behandlet og eventuell informasjon er sendt tilbake til innleverende system eller bruker.\n\nProsjektet må selv definere hvor ende-til-ende-testen skal starte og stoppe. Den kan f.eks. stoppe ved at systemet prosjektet lager har ferdigbehandlet transaksjonen og gjort den tilgjengelig til neste system, eller den kan omfatte behandling i flere sekvensielle systemer. Fokuset i en ende-til-ende-test bør være å teste en forretningsprosess fra start til slutt, på tvers av ulike virksomhetsområder og applikasjoner.\n\nEnde-til-ende-test blir også kalt verdikjedetest, men da tenker man oftest på \"hele verdikjeden\" og ikke bare deler av den."@nb ;
+        skos:prefLabel   "ende-til-ende-test (E2E)"@nb .
+
+<https://fellesdatakatalog.brreg.no/api/concepts/9aa8a3f4-9583-4278-a30e-1a3cf6151cfd>
+        a                skos:Concept ;
+        dct:identifier   "http://begrepskatalogen/begrep/2b29205f-e7e6-11e8-b7e4-005056821322" ;
+        skos:definition  "tema  i forbindelse med fastsetting av formues- og inntektsskatt som omhandler felles- formue, -gjeld, -inntekter og -kostnader som skattepliktige har knyttet til en eller flere boenheter i boligselskap eller boligsameie"@nb ;
+        skos:prefLabel   "boenheter i boligselskap eller boligsameie"@nb .
+
+<https://fellesdatakatalog.brreg.no/api/concepts/f1dacfe6-e0a9-4400-9b0c-08fb59b51d45>
+        a                skos:Concept ;
+        dct:identifier   "http://begrepskatalogen/begrep/22524018-e58b-11e7-be5a-0050568204d6" ;
+        skos:definition  "antallet heltidsansatte eller tilsvarende heltidsansatte konsernet har i det enkelte land, kan også inkludere eksterne leverandører som utfører ordinære driftsoppgaver for enheten"@nb ;
+        skos:prefLabel   "antall ansatte"@nb .
+
+<http://registration-api:8080/catalogs/910298062>
+        a              dcat:Catalog ;
+        dct:publisher  <https://organization-catalogue.staging.fellesdatakatalog.digdir.no/organizations/910298062> ;
+        dct:title      "Datakatalog for HIDRASUND OG BJONEROA"@nb ;
+        dcat:dataset   <http://brreg.no/catalogs/910298062/datasets/12136d8b-024e-4d63-a8ed-5e1885d701cd> , <http://brreg.no/catalogs/910298062/datasets/738c2348-aeb4-4a92-9a10-c39ae6b9f3fe> , <http://brreg.no/catalogs/910298062/datasets/7e4fbd01-2684-45c3-8ac1-70ebfebe8513> , <http://brreg.no/catalogs/910244132/datasets/c32b7a4f-655f-45f6-88f6-d01f05d0f7c2> .
+
+<http://brreg.no/catalogs/910298062/datasets/738c2348-aeb4-4a92-9a10-c39ae6b9f3fe>
+        a                 dcat:Dataset ;
+        dcatno:objective  "Test"@nb ;
+        dct:accessRights  <http://publications.europa.eu/resource/authority/access-right/PUBLIC> ;
+        dct:description   "Dette er en test"@nb ;
+        dct:publisher     <https://organization-catalogue.staging.fellesdatakatalog.digdir.no/organizations/910298062> ;
+        dct:references    <http://brreg.no/catalogs/910298062/datasets/12136d8b-024e-4d63-a8ed-5e1885d701cd> ;
+        dct:relation      [ a  rdfs:Resource ] ;
+        dct:title         "Mor"@nb ;
+        dcat:theme        <https://psi.norge.no/los/tema/arbeid> .

--- a/src/test/resources/fdk_ready_datasets.ttl
+++ b/src/test/resources/fdk_ready_datasets.ttl
@@ -1,0 +1,132 @@
+@prefix fdk:   <https://raw.githubusercontent.com/Informasjonsforvaltning/fdk-reasoning-service/master/src/main/resources/ontology/fdk.owl#>
+@prefix rov:   <http://www.w3.org/ns/regorg#> .
+@prefix schema: <http://schema.org/> .
+@prefix dcatapi: <http://dcat.no/dcatapi/> .
+@prefix adms:  <http://www.w3.org/ns/adms#> .
+@prefix iso:   <http://iso.org/25012/2008/dataquality/> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix dqv:   <http://www.w3.org/ns/dqv#> .
+@prefix skos:  <http://www.w3.org/2004/02/skos/core#> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+@prefix oa:    <http://www.w3.org/ns/oa#> .
+@prefix dct:   <http://purl.org/dc/terms/> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix dcatno: <http://difi.no/dcatno#> .
+@prefix dcat:  <http://www.w3.org/ns/dcat#> .
+@prefix prov:  <http://www.w3.org/ns/prov#> .
+@prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+
+<http://brreg.no/catalogs/910298062/datasets/7e4fbd01-2684-45c3-8ac1-70ebfebe8513>
+        a                          dcat:Dataset ;
+        dcatno:informationModel    [ a               skos:Concept , dct:Standard ;
+                                     dct:source      "https://www.staging.fellesdatakatalog.digdir.no/informationmodels/60ecfff8-9ea3-41ee-92cc-7e791d73dac0" ;
+                                     skos:prefLabel  "Felles informasjonsmodell for Person og Enhet"@nb
+                                   ] ;
+        dcatno:objective           "Inngangsleverandører test"@nb ;
+        dct:accessRights           <http://publications.europa.eu/resource/authority/access-right/PUBLIC> ;
+        dct:description            "Inngangsleverandører test"@nb ;
+        dct:provenance             <http://data.brreg.no/datakatalog/provinens/nasjonal> ;
+        dct:publisher              <https://organization-catalogue.staging.fellesdatakatalog.digdir.no/organizations/910244132> ;
+        dct:subject                <https://fellesdatakatalog.brreg.no/api/concepts/ac207ee9-972a-4ba9-a2d6-c368135caf0b> , <https://fellesdatakatalog.brreg.no/api/concepts/5869bbec-f894-47a7-a8de-39a6941a76d1> , <https://fellesdatakatalog.brreg.no/api/concepts/f1dacfe6-e0a9-4400-9b0c-08fb59b51d45> , <https://fellesdatakatalog.brreg.no/api/concepts/9aa8a3f4-9583-4278-a30e-1a3cf6151cfd> ;
+        dct:title                  "Inngangsleverandører test"@nb ;
+        dct:type                   "Data" ;
+        dcat:contactPoint          [ a                        vcard:Organization ;
+                                     vcard:organization-unit  "Ny test"
+                                   ] ;
+        dcat:theme                 <https://psi.norge.no/los/tema/trafikkinformasjon> , <https://psi.norge.no/los/tema/mobilitetstilbud> , <https://psi.norge.no/los/tema/helse-og-omsorg> , <https://psi.norge.no/los/ord/drivstoff-og-ladestasjoner> , <https://psi.norge.no/los/ord/reisebillett> , <https://psi.norge.no/los/tema/lov-og-rett> , <https://psi.norge.no/los/ord/ruteplanlegger> , <https://psi.norge.no/los/tema/kultur-idrett-og-fritid> ;
+        dqv:hasQualityAnnotation   [ a                dqv:QualityAnnotation ;
+                                     dqv:inDimension  <iso:Currentness> ;
+                                     prov:hasBody     []
+                                   ] ;
+        prov:qualifiedAttribution  [ a             prov:Attribution ;
+                                     dcat:hadRole  <http://registry.it.csiro.au/def/isotc211/CI_RoleCode/contributor> ;
+                                     prov:agent    <https://data.brreg.no/enhetsregisteret/api/enheter/991825827>
+                                   ] ;
+        prov:qualifiedAttribution  [ a             prov:Attribution ;
+                                     dcat:hadRole  <http://registry.it.csiro.au/def/isotc211/CI_RoleCode/contributor> ;
+                                     prov:agent    <https://data.brreg.no/enhetsregisteret/api/enheter/984582021>
+                                   ] ;
+        fdk:isAuthoritative             true .
+
+<http://brreg.no/catalogs/910244132/datasets/c32b7a4f-655f-45f6-88f6-d01f05d0f7c2>
+        a                         dcat:Dataset ;
+        dct:accessRights          <http://publications.europa.eu/resource/authority/access-right/PUBLIC> ;
+        dct:description           "bbbb\n\n---\nFormål: "@nb ;
+        dct:provenance            <http://data.brreg.no/datakatalog/provinens/nasjonal> ;
+        dct:publisher             <https://organization-catalogue.staging.fellesdatakatalog.digdir.no/organizations/910244132> ;
+        dct:title                 "Fint datasett"@nb ;
+        dcat:distribution         [ a                dcat:Distribution ;
+                                    dct:description  "Åpent"@nb ;
+                                    dct:format       "json" ;
+                                    dct:license      [ a               dct:LicenseDocument , skos:Concept ;
+                                                       dct:source      "http://data.norge.no/nlod/" ;
+                                                       skos:prefLabel  "Norsk lisens for offentlige data"@no , "Norwegian Licence for Open Government Data"@en
+                                                     ] ;
+                                    dct:title        "TEST"@nb ;
+                                    dcat:accessURL   <https://vg.no>
+                                  ] ;
+        dcat:distribution         [ a           dcat:Distribution ;
+                                    dct:format  "xml"
+                                  ] ;
+        dcat:theme                <http://publications.europa.eu/resource/authority/data-theme/EDUC> ;
+        dqv:hasQualityAnnotation  [ a                dqv:QualityAnnotation ;
+                                    dqv:inDimension  iso:Currentness ;
+                                    oa:hasBody       [ a             oa:TextualBody ;
+                                                       dct:format    <http://publications.europa.eu/resource/authority/file-type/TXT> ;
+                                                       dct:language  <http://publications.europa.eu/resource/authority/language/NOB>
+                                                     ]
+                                  ] ;
+        fdk:isAuthoritative       true .
+
+<https://fellesdatakatalog.brreg.no/api/concepts/ac207ee9-972a-4ba9-a2d6-c368135caf0b>
+        a                skos:Concept ;
+        dct:identifier   "https://dataverk.nav.no/begrep/BEGREP-1499" ;
+        skos:definition  "En digital løsning som setter en aktør i stand til selv å utføre oppgaver som ikke må utføres av en NAV-ansatt, eller som ikke kan eller bør automatiseres."@nb ;
+        skos:prefLabel   "Selvbetjeningsløsning"@nb .
+
+<http://brreg.no/catalogs/910298062/datasets/12136d8b-024e-4d63-a8ed-5e1885d701cd>
+        a                 dcat:Dataset ;
+        dcatno:objective  "Test"@nb ;
+        dct:accessRights  <http://publications.europa.eu/resource/authority/access-right/PUBLIC> ;
+        dct:description   "Dette er "@nb ;
+        dct:isPartOf      <http://brreg.no/catalogs/910298062/datasets/738c2348-aeb4-4a92-9a10-c39ae6b9f3fe> ;
+        dct:publisher     <https://organization-catalogue.staging.fellesdatakatalog.digdir.no/organizations/910298062> ;
+        dct:relation      [ a  rdfs:Resource ] ;
+        dct:title         "Datter"@nb ;
+        dcat:theme        <https://psi.norge.no/los/tema/arbeid> .
+
+<https://fellesdatakatalog.brreg.no/api/concepts/5869bbec-f894-47a7-a8de-39a6941a76d1>
+        a                skos:Concept ;
+        dct:identifier   "http://begrepskatalogen/begrep/5cd23f5a-dc82-11e5-9b2b-d6d6eb145c82" ;
+        skos:definition  "Test av en verdikjede med fokus på arbeidsprosess/arbeidsflyt og/eller transaksjonsflyt. Man tester da hendelsen/transaksjonen fra den oppstår eller kommer inn i systemet til den er ferdig behandlet og eventuell informasjon er sendt tilbake til innleverende system eller bruker.\n\nProsjektet må selv definere hvor ende-til-ende-testen skal starte og stoppe. Den kan f.eks. stoppe ved at systemet prosjektet lager har ferdigbehandlet transaksjonen og gjort den tilgjengelig til neste system, eller den kan omfatte behandling i flere sekvensielle systemer. Fokuset i en ende-til-ende-test bør være å teste en forretningsprosess fra start til slutt, på tvers av ulike virksomhetsområder og applikasjoner.\n\nEnde-til-ende-test blir også kalt verdikjedetest, men da tenker man oftest på \"hele verdikjeden\" og ikke bare deler av den."@nb ;
+        skos:prefLabel   "ende-til-ende-test (E2E)"@nb .
+
+<https://fellesdatakatalog.brreg.no/api/concepts/9aa8a3f4-9583-4278-a30e-1a3cf6151cfd>
+        a                skos:Concept ;
+        dct:identifier   "http://begrepskatalogen/begrep/2b29205f-e7e6-11e8-b7e4-005056821322" ;
+        skos:definition  "tema  i forbindelse med fastsetting av formues- og inntektsskatt som omhandler felles- formue, -gjeld, -inntekter og -kostnader som skattepliktige har knyttet til en eller flere boenheter i boligselskap eller boligsameie"@nb ;
+        skos:prefLabel   "boenheter i boligselskap eller boligsameie"@nb .
+
+<https://fellesdatakatalog.brreg.no/api/concepts/f1dacfe6-e0a9-4400-9b0c-08fb59b51d45>
+        a                skos:Concept ;
+        dct:identifier   "http://begrepskatalogen/begrep/22524018-e58b-11e7-be5a-0050568204d6" ;
+        skos:definition  "antallet heltidsansatte eller tilsvarende heltidsansatte konsernet har i det enkelte land, kan også inkludere eksterne leverandører som utfører ordinære driftsoppgaver for enheten"@nb ;
+        skos:prefLabel   "antall ansatte"@nb .
+
+<http://registration-api:8080/catalogs/910298062>
+        a              dcat:Catalog ;
+        dct:publisher  <https://organization-catalogue.staging.fellesdatakatalog.digdir.no/organizations/910298062> ;
+        dct:title      "Datakatalog for HIDRASUND OG BJONEROA"@nb ;
+        dcat:dataset   <http://brreg.no/catalogs/910298062/datasets/12136d8b-024e-4d63-a8ed-5e1885d701cd> , <http://brreg.no/catalogs/910298062/datasets/738c2348-aeb4-4a92-9a10-c39ae6b9f3fe> , <http://brreg.no/catalogs/910298062/datasets/7e4fbd01-2684-45c3-8ac1-70ebfebe8513> , <http://brreg.no/catalogs/910244132/datasets/c32b7a4f-655f-45f6-88f6-d01f05d0f7c2> .
+
+<http://brreg.no/catalogs/910298062/datasets/738c2348-aeb4-4a92-9a10-c39ae6b9f3fe>
+        a                 dcat:Dataset ;
+        dcatno:objective  "Test"@nb ;
+        dct:accessRights  <http://publications.europa.eu/resource/authority/access-right/PUBLIC> ;
+        dct:description   "Dette er en test"@nb ;
+        dct:publisher     <https://organization-catalogue.staging.fellesdatakatalog.digdir.no/organizations/910298062> ;
+        dct:references    <http://brreg.no/catalogs/910298062/datasets/12136d8b-024e-4d63-a8ed-5e1885d701cd> ;
+        dct:relation      [ a  rdfs:Resource ] ;
+        dct:title         "Mor"@nb ;
+        dcat:theme        <https://psi.norge.no/los/tema/arbeid> .


### PR DESCRIPTION
resolve #2 

Bruker `GenericRuleReasoner` for å legge til `fdk:isAuthorative` som `fdk-data-transformation-service` gjør i dag.

I `fdk-data-transformation-service` brukes sparql-spørringer for å hente ut alle datasett med provenance lik `http://data.brreg.no/datakatalog/provinens/nasjonal`, og så brukes de som subject for å legge til `fdk:isAuthorative`. Dette gjør det i ett jafs :)

ref: https://github.com/Informasjonsforvaltning/fdk-data-transformation-service/blob/main/src/main/kotlin/no/fdk/fdk_data_transformation_service/rdf/sparqlQueries.kt#L31