### PR TITLE
fix: remove exception propagation from coroutines

### DIFF
--- a/src/main/kotlin/no/fdk/fdk_reasoning_service/service/InfoModelService.kt
+++ b/src/main/kotlin/no/fdk/fdk_reasoning_service/service/InfoModelService.kt
@@ -45,11 +45,15 @@ class InfoModelService(
             }
 
     fun reasonHarvestedInformationModels() {
-        repository.findHarvestedUnion()
-            ?.let { parseRDFResponse(it, Lang.TURTLE, "information-models") }
-            ?.let { reasoningService.catalogReasoning(it, CatalogType.INFORMATIONMODELS) }
-            ?.run { separateAndSaveInformationModels() }
-            ?: run { LOGGER.error("harvested information models not found", Exception()) }
+        try {
+            repository.findHarvestedUnion()
+                ?.let { parseRDFResponse(it, Lang.TURTLE, "information-models") }
+                ?.let { reasoningService.catalogReasoning(it, CatalogType.INFORMATIONMODELS) }
+                ?.run { separateAndSaveInformationModels() }
+                ?: run { LOGGER.error("missing some or all rdf-data, reasoning of information models was stopped", Exception()) }
+        } catch (ex: Exception) {
+            LOGGER.error("reasoning of information models failed", ex)
+        }
     }
 
     private fun Model.separateAndSaveInformationModels() {

--- a/src/test/kotlin/no/fdk/fdk_reasoning_service/unit/Concepts.kt
+++ b/src/test/kotlin/no/fdk/fdk_reasoning_service/unit/Concepts.kt
@@ -8,7 +8,7 @@ import no.fdk.fdk_reasoning_service.utils.allConceptIds
 import org.apache.jena.riot.Lang
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.springframework.data.mongodb.core.MongoTemplate
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -54,7 +54,7 @@ class Concepts {
         whenever(reasoningService.catalogReasoning(any(), any()))
             .thenThrow(RuntimeException())
 
-        assertThrows<Exception> { conceptService.reasonHarvestedConcepts() }
+        assertDoesNotThrow { conceptService.reasonHarvestedConcepts() }
 
         argumentCaptor<TurtleDBO, String>().apply {
             verify(conceptMongoTemplate, times(0)).save(first.capture(), second.capture())

--- a/src/test/kotlin/no/fdk/fdk_reasoning_service/unit/DataServices.kt
+++ b/src/test/kotlin/no/fdk/fdk_reasoning_service/unit/DataServices.kt
@@ -8,7 +8,7 @@ import no.fdk.fdk_reasoning_service.utils.allDataServiceIds
 import org.apache.jena.riot.Lang
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.springframework.data.mongodb.core.MongoTemplate
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -54,7 +54,7 @@ class DataServices {
         whenever(reasoningService.catalogReasoning(any(), any()))
             .thenThrow(RuntimeException())
 
-        assertThrows<Exception> { dataServiceService.reasonHarvestedDataServices() }
+        assertDoesNotThrow { dataServiceService.reasonHarvestedDataServices() }
 
         argumentCaptor<TurtleDBO, String>().apply {
             verify(dataServiceMongoTemplate, times(0)).save(first.capture(), second.capture())

--- a/src/test/kotlin/no/fdk/fdk_reasoning_service/unit/Datasets.kt
+++ b/src/test/kotlin/no/fdk/fdk_reasoning_service/unit/Datasets.kt
@@ -9,7 +9,7 @@ import no.fdk.fdk_reasoning_service.utils.savedDatasetCollections
 import org.apache.jena.riot.Lang
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.springframework.data.mongodb.core.MongoTemplate
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -55,7 +55,7 @@ class Datasets {
         whenever(reasoningService.catalogReasoning(any(), any()))
             .thenThrow(RuntimeException())
 
-        assertThrows<Exception> { datasetService.reasonHarvestedDatasets() }
+        assertDoesNotThrow { datasetService.reasonHarvestedDatasets() }
 
         argumentCaptor<TurtleDBO, String>().apply {
             verify(datasetMongoTemplate, times(0)).save(first.capture(), second.capture())

--- a/src/test/kotlin/no/fdk/fdk_reasoning_service/unit/Events.kt
+++ b/src/test/kotlin/no/fdk/fdk_reasoning_service/unit/Events.kt
@@ -6,10 +6,7 @@ import no.fdk.fdk_reasoning_service.service.*
 import no.fdk.fdk_reasoning_service.utils.TestResponseReader
 import no.fdk.fdk_reasoning_service.utils.allEventIds
 import org.apache.jena.riot.Lang
-import org.junit.jupiter.api.Assertions
-import org.junit.jupiter.api.Tag
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.*
 import org.springframework.data.mongodb.core.MongoTemplate
 import java.util.*
 import kotlin.test.assertTrue
@@ -52,7 +49,7 @@ class Events {
         whenever(reasoningService.catalogReasoning(any(), any()))
             .thenThrow(RuntimeException())
 
-        assertThrows<Exception> { eventService.reasonHarvestedEvents() }
+        assertDoesNotThrow { eventService.reasonHarvestedEvents() }
 
         argumentCaptor<TurtleDBO, String>().apply {
             verify(eventMongoTemplate, times(0)).save(first.capture(), second.capture())

--- a/src/test/kotlin/no/fdk/fdk_reasoning_service/unit/InformationModels.kt
+++ b/src/test/kotlin/no/fdk/fdk_reasoning_service/unit/InformationModels.kt
@@ -9,7 +9,7 @@ import no.fdk.fdk_reasoning_service.utils.INFOMODEL_CATALOG_ID
 import org.apache.jena.riot.Lang
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.assertDoesNotThrow
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
@@ -57,7 +57,7 @@ class InformationModels {
         whenever(reasoningService.catalogReasoning(any(), any()))
             .thenThrow(RuntimeException())
 
-        assertThrows<Exception> { infoModelService.reasonHarvestedInformationModels() }
+        assertDoesNotThrow { infoModelService.reasonHarvestedInformationModels() }
 
         argumentCaptor<String>().apply {
             verify(repository, times(0)).saveReasonedUnion(capture())

--- a/src/test/kotlin/no/fdk/fdk_reasoning_service/unit/PublicServices.kt
+++ b/src/test/kotlin/no/fdk/fdk_reasoning_service/unit/PublicServices.kt
@@ -4,13 +4,9 @@ import com.nhaarman.mockitokotlin2.*
 import no.fdk.fdk_reasoning_service.model.TurtleDBO
 import no.fdk.fdk_reasoning_service.service.*
 import no.fdk.fdk_reasoning_service.utils.TestResponseReader
-import no.fdk.fdk_reasoning_service.utils.allEventIds
 import no.fdk.fdk_reasoning_service.utils.allPublicServiceIds
 import org.apache.jena.riot.Lang
-import org.junit.jupiter.api.Assertions
-import org.junit.jupiter.api.Tag
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.*
 import org.springframework.data.mongodb.core.MongoTemplate
 import java.util.*
 import kotlin.test.assertTrue
@@ -53,7 +49,7 @@ class PublicServices {
         whenever(reasoningService.catalogReasoning(any(), any()))
             .thenThrow(RuntimeException())
 
-        assertThrows<Exception> { publicServiceService.reasonHarvestedPublicServices() }
+        assertDoesNotThrow { publicServiceService.reasonHarvestedPublicServices() }
 
         argumentCaptor<TurtleDBO, String>().apply {
             verify(publicServiceMongoTemplate, times(0)).save(first.capture(), second.capture())

--- a/src/test/kotlin/no/fdk/fdk_reasoning_service/unit/Reasoning.kt
+++ b/src/test/kotlin/no/fdk/fdk_reasoning_service/unit/Reasoning.kt
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.io.ByteArrayOutputStream
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @Tag("unit")
@@ -36,7 +37,7 @@ class Reasoning: ApiTestContext() {
 
         val expected = responseReader.parseTurtleFile("fdk_ready_datasets.ttl")
 
-        assertTrue(result.isIsomorphicWith(expected))
+        assertTrue(result!!.isIsomorphicWith(expected))
     }
 
     @Test
@@ -49,7 +50,7 @@ class Reasoning: ApiTestContext() {
 
         val expected = responseReader.parseTurtleFile("fdk_ready_dataservices.ttl")
 
-        assertTrue(result.isIsomorphicWith(expected))
+        assertTrue(result!!.isIsomorphicWith(expected))
     }
 
     @Test
@@ -62,7 +63,7 @@ class Reasoning: ApiTestContext() {
 
         val expected = responseReader.parseTurtleFile("fdk_ready_concepts.ttl")
 
-        assertTrue(result.isIsomorphicWith(expected))
+        assertTrue(result!!.isIsomorphicWith(expected))
     }
 
     @Test
@@ -75,7 +76,7 @@ class Reasoning: ApiTestContext() {
 
         val expected = responseReader.parseTurtleFile("fdk_ready_infomodels.ttl")
 
-        assertTrue(result.isIsomorphicWith(expected))
+        assertTrue(result!!.isIsomorphicWith(expected))
     }
 
     @Test
@@ -88,7 +89,7 @@ class Reasoning: ApiTestContext() {
 
         val expected = responseReader.parseTurtleFile("fdk_ready_events.ttl")
 
-        assertTrue(result.isIsomorphicWith(expected))
+        assertTrue(result!!.isIsomorphicWith(expected))
     }
 
     @Test
@@ -101,7 +102,7 @@ class Reasoning: ApiTestContext() {
 
         val expected = responseReader.parseTurtleFile("fdk_ready_public_services.ttl")
 
-        assertTrue(result.isIsomorphicWith(expected))
+        assertTrue(result!!.isIsomorphicWith(expected))
     }
 
     @Test
@@ -111,7 +112,7 @@ class Reasoning: ApiTestContext() {
         whenever(uris.los)
             .thenReturn("http://localhost:$LOCAL_SERVER_PORT/los-error")
 
-        assertThrows<Exception> { reasoningService.catalogReasoning(responseReader.parseTurtleFile("datasets.ttl"), CatalogType.DATASETS) }
+        assertNull(reasoningService.catalogReasoning(responseReader.parseTurtleFile("datasets.ttl"), CatalogType.DATASETS))
     }
 
     @Test
@@ -121,6 +122,6 @@ class Reasoning: ApiTestContext() {
         whenever(uris.los)
             .thenReturn("http://localhost:$LOCAL_SERVER_PORT/los")
 
-        assertThrows<Exception> { reasoningService.catalogReasoning(responseReader.parseTurtleFile("concepts.ttl"), CatalogType.CONCEPTS) }
+        assertNull(reasoningService.catalogReasoning(responseReader.parseTurtleFile("concepts.ttl"), CatalogType.CONCEPTS))
     }
 }


### PR DESCRIPTION
Rimelig sikker på at det er exceptions inne i async-coroutines som er problemet, var i hvert fall det som hadde skjedd rett før det tok kvelden sist. Ser ut som de async-jobbene ikke avsluttes skikkelig ved exception, så fanger de og returnerer null i stedet.

Har i tillegg alliert meg med @valosnah for å kjøre en stresstest i staging. Vi kludrer til url'en til org-cat og/eller ref-data, slik at jobben til reasoning-service feiler i de neste timene. Om den overlever det så burde vi være i mål.

edit:
Ser ut for min del at den bestod stresstesten vi satte opp. Men kan ikke garantere at det er dette som er den faktiske feilen, vi må nesten bare la den kjøre i noen uker og se hvordan den takler det.