### PR TITLE
include removed resources in reports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.5</version>
+        <version>3.0.3</version>
         <relativePath/>
     </parent>
 
@@ -24,9 +24,9 @@
         <maven.compiler.source>${java.release}</maven.compiler.source>
         <maven.compiler.target>${java.release}</maven.compiler.target>
 
-        <kotlin.version>1.7.20</kotlin.version>
-        <testcontainers.version>1.17.5</testcontainers.version>
-        <jena.version>4.5.0</jena.version>
+        <kotlin.version>1.8.10</kotlin.version>
+        <testcontainers.version>1.17.6</testcontainers.version>
+        <jena.version>4.7.0</jena.version>
     </properties>
 
     <dependencies>
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>net.logstash.logback</groupId>
             <artifactId>logstash-logback-encoder</artifactId>
-            <version>7.2</version>
+            <version>7.3</version>
         </dependency>
 
         <dependency>
@@ -110,15 +110,15 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>com.nhaarman.mockitokotlin2</groupId>
+            <groupId>org.mockito.kotlin</groupId>
             <artifactId>mockito-kotlin</artifactId>
-            <version>2.2.0</version>
+            <version>4.1.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock</artifactId>
-            <version>2.27.2</version>
+            <version>3.0.0-beta-2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -142,7 +142,7 @@
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-suite-api</artifactId>
-            <version>1.9.0</version>
+            <version>1.9.2</version>
             <scope>test</scope>
         </dependency>
 
@@ -270,7 +270,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M7</version>
+                <version>3.0.0-M9</version>
                 <configuration>
                     <useSystemClassLoader>false</useSystemClassLoader>
                     <argLine>${surefire.jacoco.args}</argLine>
@@ -284,7 +284,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0-M7</version>
+                <version>3.0.0-M9</version>
                 <configuration>
                     <argLine>${failsafe.jacoco.args}</argLine>
                     <groups>integration</groups>

--- a/src/main/kotlin/no/fdk/fdk_reasoning_service/config/ApplicationURI.kt
+++ b/src/main/kotlin/no/fdk/fdk_reasoning_service/config/ApplicationURI.kt
@@ -1,9 +1,7 @@
 package no.fdk.fdk_reasoning_service.config
 
 import org.springframework.boot.context.properties.ConfigurationProperties
-import org.springframework.boot.context.properties.ConstructorBinding
 
-@ConstructorBinding
 @ConfigurationProperties("application.uri")
 data class ApplicationURI(
     val orgExternal: String,

--- a/src/main/kotlin/no/fdk/fdk_reasoning_service/config/MongoConnectionString.kt
+++ b/src/main/kotlin/no/fdk/fdk_reasoning_service/config/MongoConnectionString.kt
@@ -1,9 +1,7 @@
 package no.fdk.fdk_reasoning_service.config
 
 import org.springframework.boot.context.properties.ConfigurationProperties
-import org.springframework.boot.context.properties.ConstructorBinding
 
-@ConstructorBinding
 @ConfigurationProperties("spring.data.mongodb")
 data class MongoConnectionString(
     val uri: String

--- a/src/main/kotlin/no/fdk/fdk_reasoning_service/config/MongoDatabases.kt
+++ b/src/main/kotlin/no/fdk/fdk_reasoning_service/config/MongoDatabases.kt
@@ -1,9 +1,7 @@
 package no.fdk.fdk_reasoning_service.config
 
 import org.springframework.boot.context.properties.ConfigurationProperties
-import org.springframework.boot.context.properties.ConstructorBinding
 
-@ConstructorBinding
 @ConfigurationProperties("application.databases")
 data class MongoDatabases(
     val datasets: String,

--- a/src/main/kotlin/no/fdk/fdk_reasoning_service/model/Reports.kt
+++ b/src/main/kotlin/no/fdk/fdk_reasoning_service/model/Reports.kt
@@ -7,7 +7,8 @@ data class HarvestReport(
     val id: String,
     val url: String,
     val changedCatalogs: List<FdkIdAndUri> = emptyList(),
-    val changedResources: List<FdkIdAndUri> = emptyList()
+    val changedResources: List<FdkIdAndUri> = emptyList(),
+    val removedResources: List<FdkIdAndUri> = emptyList()
 )
 
 @JsonIgnoreProperties(ignoreUnknown=true)
@@ -20,7 +21,8 @@ data class ReasoningReport(
     val endTime: String,
     val errorMessage: String? = null,
     val changedCatalogs: List<FdkIdAndUri> = emptyList(),
-    val changedResources: List<FdkIdAndUri> = emptyList()
+    val changedResources: List<FdkIdAndUri> = emptyList(),
+    val removedResources: List<FdkIdAndUri> = emptyList()
 )
 
 data class FdkIdAndUri(

--- a/src/main/kotlin/no/fdk/fdk_reasoning_service/service/ConceptService.kt
+++ b/src/main/kotlin/no/fdk/fdk_reasoning_service/service/ConceptService.kt
@@ -52,7 +52,8 @@ class ConceptService(
                 startTime = start.formatWithOsloTimeZone(),
                 endTime = formatNowWithOsloTimeZone(),
                 changedCatalogs = harvestReport.changedCatalogs,
-                changedResources = harvestReport.changedResources
+                changedResources = harvestReport.changedResources,
+                removedResources = harvestReport.removedResources
             )
         } catch (ex: Exception) {
             LOGGER.error("concept reasoning failed for ${harvestReport.url}", ex)

--- a/src/main/kotlin/no/fdk/fdk_reasoning_service/service/DataServiceService.kt
+++ b/src/main/kotlin/no/fdk/fdk_reasoning_service/service/DataServiceService.kt
@@ -52,7 +52,8 @@ class DataServiceService(
                 startTime = start.formatWithOsloTimeZone(),
                 endTime = formatNowWithOsloTimeZone(),
                 changedCatalogs = harvestReport.changedCatalogs,
-                changedResources = harvestReport.changedResources
+                changedResources = harvestReport.changedResources,
+                removedResources = harvestReport.removedResources
             )
         } catch (ex: Exception) {
             LOGGER.error("data service reasoning failed for ${harvestReport.url}", ex)

--- a/src/main/kotlin/no/fdk/fdk_reasoning_service/service/DatasetService.kt
+++ b/src/main/kotlin/no/fdk/fdk_reasoning_service/service/DatasetService.kt
@@ -53,7 +53,8 @@ class DatasetService(
                 startTime = start.formatWithOsloTimeZone(),
                 endTime = formatNowWithOsloTimeZone(),
                 changedCatalogs = harvestReport.changedCatalogs,
-                changedResources = harvestReport.changedResources
+                changedResources = harvestReport.changedResources,
+                removedResources = harvestReport.removedResources
             )
         } catch (ex: Exception) {
             LOGGER.error("dataset reasoning failed for ${harvestReport.url}", ex)

--- a/src/main/kotlin/no/fdk/fdk_reasoning_service/service/EventService.kt
+++ b/src/main/kotlin/no/fdk/fdk_reasoning_service/service/EventService.kt
@@ -11,12 +11,10 @@ import no.fdk.fdk_reasoning_service.rdf.CV
 import no.fdk.fdk_reasoning_service.rdf.DCATNO
 import org.apache.jena.rdf.model.Model
 import org.apache.jena.rdf.model.ModelFactory
-import org.apache.jena.rdf.model.RDFNode
 import org.apache.jena.rdf.model.Resource
 import org.apache.jena.rdf.model.Statement
 import org.apache.jena.riot.Lang
 import org.apache.jena.vocabulary.DCAT
-import org.apache.jena.vocabulary.DCTerms
 import org.apache.jena.vocabulary.RDF
 import org.slf4j.LoggerFactory
 import org.springframework.data.mongodb.core.MongoTemplate
@@ -70,7 +68,8 @@ class EventService(
                 startTime = start.formatWithOsloTimeZone(),
                 endTime = formatNowWithOsloTimeZone(),
                 changedCatalogs = harvestReport.changedCatalogs,
-                changedResources = harvestReport.changedResources
+                changedResources = harvestReport.changedResources,
+                removedResources = harvestReport.removedResources
             )
         } catch (ex: Exception) {
             LOGGER.error("event reasoning failed for ${harvestReport.url}", ex)

--- a/src/main/kotlin/no/fdk/fdk_reasoning_service/service/InfoModelService.kt
+++ b/src/main/kotlin/no/fdk/fdk_reasoning_service/service/InfoModelService.kt
@@ -61,7 +61,8 @@ class InfoModelService(
                 startTime = start.formatWithOsloTimeZone(),
                 endTime = formatNowWithOsloTimeZone(),
                 changedCatalogs = harvestReport.changedCatalogs,
-                changedResources = harvestReport.changedResources
+                changedResources = harvestReport.changedResources,
+                removedResources = harvestReport.removedResources
             )
         } catch (ex: Exception) {
             LOGGER.error("information model reasoning failed for ${harvestReport.url}", ex)

--- a/src/main/kotlin/no/fdk/fdk_reasoning_service/service/PublicServiceService.kt
+++ b/src/main/kotlin/no/fdk/fdk_reasoning_service/service/PublicServiceService.kt
@@ -69,7 +69,8 @@ class PublicServiceService(
                 startTime = start.formatWithOsloTimeZone(),
                 endTime = formatNowWithOsloTimeZone(),
                 changedCatalogs = harvestReport.changedCatalogs,
-                changedResources = harvestReport.changedResources
+                changedResources = harvestReport.changedResources,
+                removedResources = harvestReport.removedResources
             )
         } catch (ex: Exception) {
             LOGGER.error("event reasoning failed for ${harvestReport.url}", ex)

--- a/src/test/kotlin/no/fdk/fdk_reasoning_service/unit/Concepts.kt
+++ b/src/test/kotlin/no/fdk/fdk_reasoning_service/unit/Concepts.kt
@@ -1,6 +1,5 @@
 package no.fdk.fdk_reasoning_service.unit
 
-import com.nhaarman.mockitokotlin2.*
 import no.fdk.fdk_reasoning_service.model.FdkIdAndUri
 import no.fdk.fdk_reasoning_service.model.ReasoningReport
 import no.fdk.fdk_reasoning_service.model.TurtleDBO
@@ -11,6 +10,7 @@ import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
+import org.mockito.kotlin.*
 import org.springframework.data.mongodb.core.MongoTemplate
 import org.springframework.data.mongodb.core.findAll
 import java.util.*

--- a/src/test/kotlin/no/fdk/fdk_reasoning_service/unit/DataServices.kt
+++ b/src/test/kotlin/no/fdk/fdk_reasoning_service/unit/DataServices.kt
@@ -1,6 +1,5 @@
 package no.fdk.fdk_reasoning_service.unit
 
-import com.nhaarman.mockitokotlin2.*
 import no.fdk.fdk_reasoning_service.model.FdkIdAndUri
 import no.fdk.fdk_reasoning_service.model.ReasoningReport
 import no.fdk.fdk_reasoning_service.model.TurtleDBO
@@ -11,6 +10,7 @@ import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
+import org.mockito.kotlin.*
 import org.springframework.data.mongodb.core.MongoTemplate
 import org.springframework.data.mongodb.core.findAll
 import java.util.Collections

--- a/src/test/kotlin/no/fdk/fdk_reasoning_service/unit/Datasets.kt
+++ b/src/test/kotlin/no/fdk/fdk_reasoning_service/unit/Datasets.kt
@@ -1,6 +1,5 @@
 package no.fdk.fdk_reasoning_service.unit
 
-import com.nhaarman.mockitokotlin2.*
 import no.fdk.fdk_reasoning_service.model.FdkIdAndUri
 import no.fdk.fdk_reasoning_service.model.ReasoningReport
 import no.fdk.fdk_reasoning_service.model.TurtleDBO
@@ -11,6 +10,7 @@ import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
+import org.mockito.kotlin.*
 import org.springframework.data.mongodb.core.MongoTemplate
 import org.springframework.data.mongodb.core.findAll
 import java.util.Collections

--- a/src/test/kotlin/no/fdk/fdk_reasoning_service/unit/Events.kt
+++ b/src/test/kotlin/no/fdk/fdk_reasoning_service/unit/Events.kt
@@ -1,6 +1,5 @@
 package no.fdk.fdk_reasoning_service.unit
 
-import com.nhaarman.mockitokotlin2.*
 import no.fdk.fdk_reasoning_service.model.FdkIdAndUri
 import no.fdk.fdk_reasoning_service.model.ReasoningReport
 import no.fdk.fdk_reasoning_service.model.TurtleDBO
@@ -8,6 +7,7 @@ import no.fdk.fdk_reasoning_service.service.*
 import no.fdk.fdk_reasoning_service.utils.*
 import org.apache.jena.riot.Lang
 import org.junit.jupiter.api.*
+import org.mockito.kotlin.*
 import org.springframework.data.mongodb.core.MongoTemplate
 import org.springframework.data.mongodb.core.findAll
 import java.util.*

--- a/src/test/kotlin/no/fdk/fdk_reasoning_service/unit/InformationModels.kt
+++ b/src/test/kotlin/no/fdk/fdk_reasoning_service/unit/InformationModels.kt
@@ -1,6 +1,5 @@
 package no.fdk.fdk_reasoning_service.unit
 
-import com.nhaarman.mockitokotlin2.*
 import no.fdk.fdk_reasoning_service.model.FdkIdAndUri
 import no.fdk.fdk_reasoning_service.model.ReasoningReport
 import no.fdk.fdk_reasoning_service.repository.InformationModelRepository
@@ -10,6 +9,7 @@ import org.apache.jena.riot.Lang
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
+import org.mockito.kotlin.*
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 

--- a/src/test/kotlin/no/fdk/fdk_reasoning_service/unit/PublicServices.kt
+++ b/src/test/kotlin/no/fdk/fdk_reasoning_service/unit/PublicServices.kt
@@ -1,13 +1,12 @@
 package no.fdk.fdk_reasoning_service.unit
 
-import com.nhaarman.mockitokotlin2.*
-import no.fdk.fdk_reasoning_service.model.FdkIdAndUri
 import no.fdk.fdk_reasoning_service.model.ReasoningReport
 import no.fdk.fdk_reasoning_service.model.TurtleDBO
 import no.fdk.fdk_reasoning_service.service.*
 import no.fdk.fdk_reasoning_service.utils.*
 import org.apache.jena.riot.Lang
 import org.junit.jupiter.api.*
+import org.mockito.kotlin.*
 import org.springframework.data.mongodb.core.MongoTemplate
 import org.springframework.data.mongodb.core.findAll
 import java.util.*

--- a/src/test/kotlin/no/fdk/fdk_reasoning_service/unit/Reasoning.kt
+++ b/src/test/kotlin/no/fdk/fdk_reasoning_service/unit/Reasoning.kt
@@ -1,13 +1,13 @@
 package no.fdk.fdk_reasoning_service.unit
 
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.whenever
 import no.fdk.fdk_reasoning_service.config.ApplicationURI
 import no.fdk.fdk_reasoning_service.model.CatalogType
 import no.fdk.fdk_reasoning_service.service.ReasoningService
 import no.fdk.fdk_reasoning_service.utils.*
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 import kotlin.test.assertTrue
 
 @Tag("unit")

--- a/src/test/kotlin/no/fdk/fdk_reasoning_service/unit/Retry.kt
+++ b/src/test/kotlin/no/fdk/fdk_reasoning_service/unit/Retry.kt
@@ -1,7 +1,5 @@
 package no.fdk.fdk_reasoning_service.unit
 
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.whenever
 import no.fdk.fdk_reasoning_service.config.ApplicationURI
 import no.fdk.fdk_reasoning_service.model.CatalogType
 import no.fdk.fdk_reasoning_service.model.RetryReportsWrap
@@ -18,6 +16,8 @@ import no.fdk.fdk_reasoning_service.utils.LOCAL_SERVER_PORT
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 import kotlin.test.assertTrue
 
 @Tag("unit")

--- a/src/test/kotlin/no/fdk/fdk_reasoning_service/utils/ApiTestContext.kt
+++ b/src/test/kotlin/no/fdk/fdk_reasoning_service/utils/ApiTestContext.kt
@@ -2,7 +2,7 @@ package no.fdk.fdk_reasoning_service.utils
 
 import org.slf4j.LoggerFactory
 import org.springframework.boot.test.util.TestPropertyValues
-import org.springframework.boot.web.server.LocalServerPort
+import org.springframework.boot.test.web.server.LocalServerPort
 import org.springframework.context.ApplicationContextInitializer
 import org.springframework.context.ConfigurableApplicationContext
 import org.testcontainers.containers.GenericContainer


### PR DESCRIPTION
nye tjenesten @terjesyl jobber med vil ha behov for info om removedResources, videresender det bare i reasoning-rapportene slik at parser-service slipper å i tillegg måtte lytte etter høsterapporter