### PR TITLE
fix: rm support of hasCompetentAuthority for events

### DIFF
--- a/src/main/kotlin/no/fdk/fdk_reasoning_service/service/ReasoningService.kt
+++ b/src/main/kotlin/no/fdk/fdk_reasoning_service/service/ReasoningService.kt
@@ -35,7 +35,6 @@ class ReasoningService(
 
     private fun CatalogType.extendedPublishersModel(orgData: Model, catalogData: Model): Model {
         val publisherPredicates = when (this) {
-            CatalogType.EVENTS -> listOf(CV.hasCompetentAuthority)
             CatalogType.PUBLICSERVICES -> listOf(CV.hasCompetentAuthority, CV.ownedBy)
             else -> listOf(DCTerms.publisher)
         }

--- a/src/test/resources/events.ttl
+++ b/src/test/resources/events.ttl
@@ -44,7 +44,6 @@
 
 <http://public-service-publisher.fellesdatakatalog.digdir.no/events/09c9429e-af32-4387-b14b-f24ac0c37265>
         a                         cv:LifeEvent ;
-        cv:hasCompetentAuthority  <https://organization-catalog.fellesdatakatalog.digdir.no/organizations/910244132> ;
         dct:description           "ASD forvalter i dag flere ordninger i folketrygdloven med relevans for livshendelsen. Direktoratet forvalter også ordninger som tilhører BFD. I forbindelse med direktoratets langsiktige IKT-moderniseringsarbeid er det innført digitale tjenester for innsyn, dialog, samhandling og automatisert saksbehandling for foreldrepenger og pleiepenger. Dette digitaliseringsarbeidet understøtter målsettingene i digitaliseringsstrategien."@nb ;
         dct:identifier            "09c9429e-af32-4387-b14b-f24ac0c37265" ;
         dct:relation              <http://public-service-publisher.fellesdatakatalog.digdir.no/services/13> ;
@@ -96,7 +95,6 @@
 
 <http://public-service-publisher.fellesdatakatalog.digdir.no/events/745d1372-2b71-4e20-bcc4-49023379e7cf>
         a                         cv:BusinessEvent ;
-        cv:hasCompetentAuthority  <https://organization-catalog.fellesdatakatalog.digdir.no/organizations/912660680> ;
         dct:description           "Den overordnede målsetningen er forenkle for den næringsdrivende i alle faser (Idé-, etablering-, drive- og avslutningsfase) gjennom å se stegene den næringsdrivende må gjennom i sammenheng. Videre å etablere sammenhengende forretningstjenester med fokus på virksomheten på tvers av offentlig sektor, men også på tvers av privat og offentlig sektor. Brønnøysundregistrenes arbeid går ut på å etablere en metodikk for arbeidet, identifisere og koordinere tiltak, og i noen tilfeller gjennomføre tiltak som bidrar til forenklingen og gevinster for næringslivet. I tillegg en tett dialog med offentlige private sektorutvikling (OPS) porteføljene."@nb ;
         dct:identifier            "745d1372-2b71-4e20-bcc4-49023379e7cf" ;
         dct:relation              <http://public-service-publisher.fellesdatakatalog.digdir.no/services/1> ;
@@ -149,7 +147,7 @@
         a       dcat:Catalog ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                         "Testdirektoratet - Hendelsekatalog"@nb , "TESTDIREKTORATET - Hendingskatalog"@nn , "TESTDIREKTORATET - Event catalog"@en ;
-        dct:publisher  <http://localhost:5000/organizations/123456789> ;
+        dct:publisher  <https://organization-catalog.fellesdatakatalog.digdir.no/organizations/910244132> ;
         dcatno:containsEvent <http://public-service-publisher.fellesdatakatalog.digdir.no/events/745d1372-2b71-4e20-bcc4-49023379e7cf> ,
             <http://public-service-publisher.fellesdatakatalog.digdir.no/events/09c9429e-af32-4387-b14b-f24ac0c37265> .
 

--- a/src/test/resources/reasoned_event_0.ttl
+++ b/src/test/resources/reasoned_event_0.ttl
@@ -44,7 +44,6 @@
 
 <http://public-service-publisher.fellesdatakatalog.digdir.no/events/09c9429e-af32-4387-b14b-f24ac0c37265>
         a                         cv:LifeEvent ;
-        cv:hasCompetentAuthority  <https://organization-catalog.fellesdatakatalog.digdir.no/organizations/910244132> ;
         dct:description           "ASD forvalter i dag flere ordninger i folketrygdloven med relevans for livshendelsen. Direktoratet forvalter også ordninger som tilhører BFD. I forbindelse med direktoratets langsiktige IKT-moderniseringsarbeid er det innført digitale tjenester for innsyn, dialog, samhandling og automatisert saksbehandling for foreldrepenger og pleiepenger. Dette digitaliseringsarbeidet understøtter målsettingene i digitaliseringsstrategien."@nb ;
         dct:identifier            "09c9429e-af32-4387-b14b-f24ac0c37265" ;
         dct:relation              <http://public-service-publisher.fellesdatakatalog.digdir.no/services/13> ;
@@ -106,7 +105,7 @@
         a                     dcat:Catalog;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "Testdirektoratet - Hendelsekatalog"@nb , "TESTDIREKTORATET - Hendingskatalog"@nn , "TESTDIREKTORATET - Event catalog"@en;
-        dct:publisher         <http://localhost:5000/organizations/123456789>;
+        dct:publisher         <https://organization-catalog.fellesdatakatalog.digdir.no/organizations/910244132>;
         dcatno:containsEvent  <http://public-service-publisher.fellesdatakatalog.digdir.no/events/745d1372-2b71-4e20-bcc4-49023379e7cf> , <http://public-service-publisher.fellesdatakatalog.digdir.no/events/09c9429e-af32-4387-b14b-f24ac0c37265> .
 
 <http://localhost:5000/events/catalogs/4d2c9e29-2f9a-304f-9e48-34e30a36d068>

--- a/src/test/resources/reasoned_event_1.ttl
+++ b/src/test/resources/reasoned_event_1.ttl
@@ -17,7 +17,6 @@
 
 <http://public-service-publisher.fellesdatakatalog.digdir.no/events/745d1372-2b71-4e20-bcc4-49023379e7cf>
         a                         cv:BusinessEvent ;
-        cv:hasCompetentAuthority  <https://organization-catalog.fellesdatakatalog.digdir.no/organizations/912660680> ;
         dct:description           "Den overordnede målsetningen er forenkle for den næringsdrivende i alle faser (Idé-, etablering-, drive- og avslutningsfase) gjennom å se stegene den næringsdrivende må gjennom i sammenheng. Videre å etablere sammenhengende forretningstjenester med fokus på virksomheten på tvers av offentlig sektor, men også på tvers av privat og offentlig sektor. Brønnøysundregistrenes arbeid går ut på å etablere en metodikk for arbeidet, identifisere og koordinere tiltak, og i noen tilfeller gjennomføre tiltak som bidrar til forenklingen og gevinster for næringslivet. I tillegg en tett dialog med offentlige private sektorutvikling (OPS) porteføljene."@nb ;
         dct:identifier            "745d1372-2b71-4e20-bcc4-49023379e7cf" ;
         dct:relation              <http://public-service-publisher.fellesdatakatalog.digdir.no/services/1> ;
@@ -70,7 +69,7 @@
         a                     dcat:Catalog;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "Testdirektoratet - Hendelsekatalog"@nb , "TESTDIREKTORATET - Hendingskatalog"@nn , "TESTDIREKTORATET - Event catalog"@en;
-        dct:publisher         <http://localhost:5000/organizations/123456789>;
+        dct:publisher         <https://organization-catalog.fellesdatakatalog.digdir.no/organizations/910244132>;
         dcatno:containsEvent  <http://public-service-publisher.fellesdatakatalog.digdir.no/events/745d1372-2b71-4e20-bcc4-49023379e7cf> , <http://public-service-publisher.fellesdatakatalog.digdir.no/events/09c9429e-af32-4387-b14b-f24ac0c37265> .
 
 <http://localhost:5000/events/catalogs/4d2c9e29-2f9a-304f-9e48-34e30a36d068>
@@ -79,3 +78,11 @@
         dct:issued         "2020-10-05T13:15:39.831Z"^^xsd:dateTime;
         dct:modified       "2020-10-05T13:15:39.831Z"^^xsd:dateTime;
         foaf:primaryTopic  <http://localhost:5000/fdk-public-service-publisher.ttl#GeneratedCatalog> .
+
+<https://organization-catalog.fellesdatakatalog.digdir.no/organizations/910244132>
+        a               rov:RegisteredOrganization ;
+        dct:identifier  "910244132" ;
+        rov:legalName   "RAMSUND OG ROGNAN REVISJON" ;
+        rov:orgType     orgtype:ASA ;
+        foaf:name       "Ramsund og Rognand revisjon"@nb ;
+        br:orgPath      "/ANNET/910244132" .

--- a/src/test/resources/reasoned_event_catalogs.ttl
+++ b/src/test/resources/reasoned_event_catalogs.ttl
@@ -17,7 +17,6 @@
 
 <http://public-service-publisher.fellesdatakatalog.digdir.no/events/09c9429e-af32-4387-b14b-f24ac0c37265>
         a                         cv:LifeEvent ;
-        cv:hasCompetentAuthority  <https://organization-catalog.fellesdatakatalog.digdir.no/organizations/910244132> ;
         dct:description           "ASD forvalter i dag flere ordninger i folketrygdloven med relevans for livshendelsen. Direktoratet forvalter også ordninger som tilhører BFD. I forbindelse med direktoratets langsiktige IKT-moderniseringsarbeid er det innført digitale tjenester for innsyn, dialog, samhandling og automatisert saksbehandling for foreldrepenger og pleiepenger. Dette digitaliseringsarbeidet understøtter målsettingene i digitaliseringsstrategien."@nb ;
         dct:identifier            "09c9429e-af32-4387-b14b-f24ac0c37265" ;
         dct:relation              <http://public-service-publisher.fellesdatakatalog.digdir.no/services/13> ;
@@ -85,7 +84,6 @@
 
 <http://public-service-publisher.fellesdatakatalog.digdir.no/events/745d1372-2b71-4e20-bcc4-49023379e7cf>
         a                         cv:BusinessEvent ;
-        cv:hasCompetentAuthority  <https://organization-catalog.fellesdatakatalog.digdir.no/organizations/912660680> ;
         dct:description           "Den overordnede målsetningen er forenkle for den næringsdrivende i alle faser (Idé-, etablering-, drive- og avslutningsfase) gjennom å se stegene den næringsdrivende må gjennom i sammenheng. Videre å etablere sammenhengende forretningstjenester med fokus på virksomheten på tvers av offentlig sektor, men også på tvers av privat og offentlig sektor. Brønnøysundregistrenes arbeid går ut på å etablere en metodikk for arbeidet, identifisere og koordinere tiltak, og i noen tilfeller gjennomføre tiltak som bidrar til forenklingen og gevinster for næringslivet. I tillegg en tett dialog med offentlige private sektorutvikling (OPS) porteføljene."@nb ;
         dct:identifier            "745d1372-2b71-4e20-bcc4-49023379e7cf" ;
         dct:relation              <http://public-service-publisher.fellesdatakatalog.digdir.no/services/1> ;
@@ -160,7 +158,7 @@
         a       dcat:Catalog ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                         "Testdirektoratet - Hendelsekatalog"@nb , "TESTDIREKTORATET - Hendingskatalog"@nn , "TESTDIREKTORATET - Event catalog"@en ;
-        dct:publisher  <http://localhost:5000/organizations/123456789> ;
+        dct:publisher  <https://organization-catalog.fellesdatakatalog.digdir.no/organizations/910244132> ;
         dcatno:containsEvent <http://public-service-publisher.fellesdatakatalog.digdir.no/events/745d1372-2b71-4e20-bcc4-49023379e7cf> ,
             <http://public-service-publisher.fellesdatakatalog.digdir.no/events/09c9429e-af32-4387-b14b-f24ac0c37265> .
 


### PR DESCRIPTION
part of: https://github.com/Informasjonsforvaltning/fdk-issue-tracker/issues/828

`cv:hasCompetentAuthority` er ikke en del av spesifikasjonen for hendelser, så fjerner støtte for den i reasoning, siden hendelser ikke har en direkte kobling til en org så må vi i stedet bruke `dct:publisher` fra katalogen.