### PR TITLE
fix: better null check in addOrgPathWhenMissing

### DIFF
--- a/src/main/kotlin/no/fdk/fdk_reasoning_service/service/OrganizationService.kt
+++ b/src/main/kotlin/no/fdk/fdk_reasoning_service/service/OrganizationService.kt
@@ -95,7 +95,7 @@ class OrganizationService(
                         ?.let { orgId -> orgData.getResource(orgURI(orgId, orgBaseURI)) },
                 )
             }
-            .filter { it.second != null }
+            .filter { it.second?.getProperty(BR.orgPath)?.`object` != null }
             .forEach { orgPaths.add(orgPaths.createResource(it.first.uri), BR.orgPath, it.second?.getProperty(BR.orgPath)?.`object`) }
 
         organizationsMissingOrgPath


### PR DESCRIPTION
vi får denne feilmeldingen i prod nå:
````
Error occurred during reasoning","message":"java.lang.NullPointerException: Cannot invoke \"org.apache.jena.rdf.model.RDFNode.asNode()\" because \"o\" is null
at org.apache.jena.rdf.model.impl.ModelCom.add(ModelCom.java:1030)
at no.fdk.fdk_reasoning_service.service.OrganizationService.addOrgPathWhenMissing(OrganizationService.kt:99)
````

Som gjør at circuit-breaker slår til og ingen datasett vil få gjennomført reasoning
-> ingen datasett blir oppdatert i portal

Dette burde fikse det