### PR TITLE
feat: add openLicenses to data service ref data

### DIFF
--- a/src/main/kotlin/no/fdk/fdk_reasoning_service/service/ReferenceDataService.kt
+++ b/src/main/kotlin/no/fdk/fdk_reasoning_service/service/ReferenceDataService.kt
@@ -51,9 +51,13 @@ class ReferenceDataService(
         val fileTypes = referenceDataCache.fileTypes()
         if (fileTypes.isEmpty) throw Exception("File types are missing in reference data cache")
 
+        val openLicenses = referenceDataCache.openLicenses()
+        if (openLicenses.isEmpty) throw Exception("Open licenses are missing in reference data cache")
+
         val m = ModelFactory.createDefaultModel()
         m.add(ianaMediaTypes)
         m.add(fileTypes)
+        m.add(openLicenses)
         return m
     }
 

--- a/src/test/kotlin/no/fdk/fdk_reasoning_service/unit/ReferenceData.kt
+++ b/src/test/kotlin/no/fdk/fdk_reasoning_service/unit/ReferenceData.kt
@@ -133,6 +133,23 @@ class ReferenceData {
 
             assertTrue(result.isIsomorphicWith(expected))
         }
+
+        @Test
+        fun `test open licenses are added from reference data`() {
+            val input = responseReader.parseTurtleFile("rdf-data/input-graphs/data_service.ttl")
+            input.add(input.getResource(dataServiceURI), DCTerms.license, input.createResource("http://publications.europa.eu/resource/authority/licence/CC_BY_4_0"))
+
+            val result = referenceDataService.reason(input, CatalogType.DATASERVICES)
+
+            assertTrue(
+                result.contains(
+                    ResourceFactory.createResource("http://publications.europa.eu/resource/authority/licence/CC_BY_4_0"),
+                    SKOS.prefLabel,
+                    "Creative Commons Attribution 4.0 International",
+                    "en"
+                )
+            )
+        }
     }
 
 


### PR DESCRIPTION
# Summary fixes #254

- Add `openLicenses` to `dataServiceReferenceData()` so license triples are resolved for data services
- Add unit test verifying open licenses are added from reference data